### PR TITLE
Bug: module name cannot have uppercase characters

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,7 +6,7 @@
 ###############################################################################
 
 module(
-    name = "WheelOS",
+    name = "wheel.os",
     version = "1.0.0",
     compatibility_level = 1,
 )


### PR DESCRIPTION
From the bazel [documentation](https://bazel.build/rules/lib/globals/module#parameters_6)

> The name of the module. Can be omitted only if this module is the root module (as in, if it's not going to be depended on by another module). A valid module name must: 1) only contain lowercase letters (a-z), digits (0-9), dots (.), hyphens (-), and underscores (_); 2) begin with a lowercase letter; 3) end with a lowercase letter or digit.